### PR TITLE
Light version of data containers for expressions

### DIFF
--- a/src/dawn/AST/ASTExpr.cpp
+++ b/src/dawn/AST/ASTExpr.cpp
@@ -323,10 +323,13 @@ VarAccessExpr::VarAccessExpr(const std::string& name, std::shared_ptr<Expr> inde
 
 VarAccessExpr::VarAccessExpr(const VarAccessExpr& expr)
     : Expr(EK_VarAccessExpr, expr.getSourceLocation()), name_(expr.getName()),
-      index_(expr.getIndex()), isExternal_(expr.isExternal()) {}
+      index_(expr.getIndex()), isExternal_(expr.isExternal()) {
+  data_ = expr.data_ ? expr.data_->clone() : nullptr;
+}
 
 VarAccessExpr& VarAccessExpr::operator=(VarAccessExpr expr) {
   assign(expr);
+  data_ = expr.data_ ? expr.data_->clone() : nullptr;
   name_ = std::move(expr.getName());
   index_ = std::move(expr.getIndex());
   isExternal_ = expr.isExternal();
@@ -369,10 +372,13 @@ FieldAccessExpr::FieldAccessExpr(const std::string& name, Array3i offset, Array3
 FieldAccessExpr::FieldAccessExpr(const FieldAccessExpr& expr)
     : Expr(EK_FieldAccessExpr, expr.getSourceLocation()), name_(expr.getName()),
       offset_(expr.getOffset()), argumentMap_(expr.getArgumentMap()),
-      argumentOffset_(expr.getArgumentOffset()), negateOffset_(expr.negateOffset()) {}
+      argumentOffset_(expr.getArgumentOffset()), negateOffset_(expr.negateOffset()) {
+  data_ = expr.data_ ? expr.data_->clone() : nullptr;
+}
 
 FieldAccessExpr& FieldAccessExpr::operator=(FieldAccessExpr expr) {
   assign(expr);
+  data_ = expr.data_ ? expr.data_->clone() : nullptr;
   name_ = std::move(expr.getName());
   offset_ = std::move(expr.getOffset());
   argumentMap_ = std::move(expr.getArgumentMap());

--- a/src/dawn/AST/ASTExpr.h
+++ b/src/dawn/AST/ASTExpr.h
@@ -416,7 +416,8 @@ public:
 
   /// @brief Get data object, must provide the type of the data object (must be subtype of
   /// VarAccessExprData)
-  template <typename DataType, typename = enable_if_subtype_t<DataType, VarAccessExprData>>
+  template <typename DataType, typename = typename std::enable_if<
+                                   std::is_base_of<VarAccessExprData, DataType>::value>::type>
   DataType& getData() {
     if(!data_)
       data_ = make_unique<DataType>();
@@ -522,12 +523,10 @@ public:
   /// This function is used during the inlining when we now all the offsets.
   void setPureOffset(const Array3i& offset);
 
-  template <typename Sub, typename Base>
-  using enable_if_subtype_t = typename std::enable_if<std::is_base_of<Base, Sub>::value>::type;
-
   /// @brief Get data object, must provide the type of the data object (must be subtype of
   /// FieldAccessExprData)
-  template <typename DataType, typename = enable_if_subtype_t<DataType, FieldAccessExprData>>
+  template <typename DataType, typename = typename std::enable_if<
+                                   std::is_base_of<FieldAccessExprData, DataType>::value>::type>
   DataType& getData() {
     if(!data_)
       data_ = make_unique<DataType>();


### PR DESCRIPTION
Don't need makers. Only FieldAccessExpr and VarAccessExpr need data (and only IIR data).